### PR TITLE
Standardize the `HandlerInfo` source

### DIFF
--- a/pkg/gohandlers/handlers.go
+++ b/pkg/gohandlers/handlers.go
@@ -1,0 +1,9 @@
+package gohandlers
+
+import "net/http"
+
+type HandlerInfo struct {
+	Method string
+	Path   string
+	Ref    http.HandlerFunc
+}


### PR DESCRIPTION
**Todo**

- [x] Expose a standard `HandlerInfo` declaration in a public package, under `pkg` folder.
- [x] Modify the `list` command's AST generator to
  - [x] Embed an import spec for `HandlerInfo` providing package
  - [x] Use the `package.HandlerInfo` as type expression in list function return type and map declaration.
- [x] Remove the flags from `list` command dispatcher