### PR TITLE
Fixes the module name dependence on the mirror

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build
 
 VERSION := $(shell git describe --tags --always --dirty)
-LDFLAGS := -ldflags "-X 'github.com/ufukty/gohandlers/cmd/gohandlers/commands/version.Version=$(VERSION)'"
+LDFLAGS := -ldflags "-X 'go.ufukty.com/gohandlers/cmd/gohandlers/commands/version.Version=$(VERSION)'"
 
 build:
 	@echo "Version $(VERSION)..."

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 > Work in progress.
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/ufukty/gohandlers)](https://goreportcard.com/report/github.com/ufukty/gohandlers)
-[![pkg.go.dev](https://pkg.go.dev/badge/github.com/ufukty/gohandlers)](https://pkg.go.dev/github.com/ufukty/gohandlers)
-[![Release](https://img.shields.io/github/v/release/ufukty/gohandlers)](https://github.com/ufukty/gohandlers/releases)
+[![Go Report Card](https://goreportcard.com/badge/go.ufukty.com/gohandlers)](https://goreportcard.com/report/go.ufukty.com/gohandlers)
+[![pkg.go.dev](https://pkg.go.dev/badge/go.ufukty.com/gohandlers)](https://pkg.go.dev/go.ufukty.com/gohandlers)
+[![Release](https://img.shields.io/github/v/release/ufukty/gohandlers)](https://go.ufukty.com/gohandlers/releases)
 
 # gohandlers
 

--- a/cmd/gohandlers/commands/client/construct/client.go
+++ b/cmd/gohandlers/commands/client/construct/client.go
@@ -5,7 +5,7 @@ import (
 	"go/token"
 	"slices"
 
-	"github.com/ufukty/gohandlers/pkg/inspects"
+	"go.ufukty.com/gohandlers/pkg/inspects"
 )
 
 func ternary[T any](cond bool, t, f T) T {

--- a/cmd/gohandlers/commands/client/construct/file.go
+++ b/cmd/gohandlers/commands/client/construct/file.go
@@ -3,7 +3,7 @@ package construct
 import (
 	"go/ast"
 
-	"github.com/ufukty/gohandlers/pkg/inspects"
+	"go.ufukty.com/gohandlers/pkg/inspects"
 )
 
 func File(infoss map[inspects.Receiver]map[string]inspects.Info, pkgdst, pkgsrc, importpkg string) *ast.File {

--- a/cmd/gohandlers/commands/client/construct/imports.go
+++ b/cmd/gohandlers/commands/client/construct/imports.go
@@ -5,7 +5,7 @@ import (
 	"go/ast"
 	"go/token"
 
-	"github.com/ufukty/gohandlers/cmd/gohandlers/internal/pretty/sort"
+	"go.ufukty.com/gohandlers/cmd/gohandlers/internal/pretty/sort"
 )
 
 func imports(importpkg string) ast.Decl {

--- a/cmd/gohandlers/commands/client/construct/mock.go
+++ b/cmd/gohandlers/commands/client/construct/mock.go
@@ -7,7 +7,7 @@ import (
 	"go/token"
 	"slices"
 
-	"github.com/ufukty/gohandlers/pkg/inspects"
+	"go.ufukty.com/gohandlers/pkg/inspects"
 )
 
 func methodtype(hi inspects.Info, pkgsrc string, imported, namedparams bool) *ast.FuncType {

--- a/cmd/gohandlers/commands/client/main.go
+++ b/cmd/gohandlers/commands/client/main.go
@@ -6,9 +6,9 @@ import (
 	"io"
 	"os"
 
-	"github.com/ufukty/gohandlers/cmd/gohandlers/commands/client/construct"
-	"github.com/ufukty/gohandlers/cmd/gohandlers/internal/pretty"
-	"github.com/ufukty/gohandlers/pkg/inspects"
+	"go.ufukty.com/gohandlers/cmd/gohandlers/commands/client/construct"
+	"go.ufukty.com/gohandlers/cmd/gohandlers/internal/pretty"
+	"go.ufukty.com/gohandlers/pkg/inspects"
 )
 
 type Args struct {

--- a/cmd/gohandlers/commands/helpers/internal/construct/bqbuild.go
+++ b/cmd/gohandlers/commands/helpers/internal/construct/bqbuild.go
@@ -5,8 +5,8 @@ import (
 	"go/ast"
 	"go/token"
 
-	"github.com/ufukty/gohandlers/internal/sorted"
-	"github.com/ufukty/gohandlers/pkg/inspects"
+	"go.ufukty.com/gohandlers/internal/sorted"
+	"go.ufukty.com/gohandlers/pkg/inspects"
 )
 
 type bqBuildSymbolTable struct {

--- a/cmd/gohandlers/commands/helpers/internal/construct/bqparse.go
+++ b/cmd/gohandlers/commands/helpers/internal/construct/bqparse.go
@@ -5,8 +5,8 @@ import (
 	"go/ast"
 	"go/token"
 
-	"github.com/ufukty/gohandlers/internal/sorted"
-	"github.com/ufukty/gohandlers/pkg/inspects"
+	"go.ufukty.com/gohandlers/internal/sorted"
+	"go.ufukty.com/gohandlers/pkg/inspects"
 )
 
 type bqParse struct{}

--- a/cmd/gohandlers/commands/helpers/internal/construct/bqunmarshalform.go
+++ b/cmd/gohandlers/commands/helpers/internal/construct/bqunmarshalform.go
@@ -5,8 +5,8 @@ import (
 	"go/ast"
 	"go/token"
 
-	"github.com/ufukty/gohandlers/internal/sorted"
-	"github.com/ufukty/gohandlers/pkg/inspects"
+	"go.ufukty.com/gohandlers/internal/sorted"
+	"go.ufukty.com/gohandlers/pkg/inspects"
 )
 
 func BqUnmarshalFormData(i inspects.Info) *ast.FuncDecl {

--- a/cmd/gohandlers/commands/helpers/internal/construct/bqvalidate.go
+++ b/cmd/gohandlers/commands/helpers/internal/construct/bqvalidate.go
@@ -4,8 +4,8 @@ import (
 	"go/ast"
 	"go/token"
 
-	"github.com/ufukty/gohandlers/internal/sorted"
-	"github.com/ufukty/gohandlers/pkg/inspects"
+	"go.ufukty.com/gohandlers/internal/sorted"
+	"go.ufukty.com/gohandlers/pkg/inspects"
 )
 
 func merge[K comparable, V any](maps ...map[K]V) map[K]V {

--- a/cmd/gohandlers/commands/helpers/internal/construct/bsparse.go
+++ b/cmd/gohandlers/commands/helpers/internal/construct/bsparse.go
@@ -4,7 +4,7 @@ import (
 	"go/ast"
 	"go/token"
 
-	"github.com/ufukty/gohandlers/pkg/inspects"
+	"go.ufukty.com/gohandlers/pkg/inspects"
 )
 
 type bsParse struct{}

--- a/cmd/gohandlers/commands/helpers/internal/construct/bswrite.go
+++ b/cmd/gohandlers/commands/helpers/internal/construct/bswrite.go
@@ -4,7 +4,7 @@ import (
 	"go/ast"
 	"go/token"
 
-	"github.com/ufukty/gohandlers/pkg/inspects"
+	"go.ufukty.com/gohandlers/pkg/inspects"
 )
 
 type bsWrite struct{}

--- a/cmd/gohandlers/commands/helpers/internal/construct/listers.go
+++ b/cmd/gohandlers/commands/helpers/internal/construct/listers.go
@@ -5,7 +5,7 @@ import (
 	"go/token"
 	"slices"
 
-	"github.com/ufukty/gohandlers/pkg/inspects"
+	"go.ufukty.com/gohandlers/pkg/inspects"
 )
 
 func Listers(infoss map[inspects.Receiver]map[string]inspects.Info) []ast.Decl {

--- a/cmd/gohandlers/commands/helpers/internal/imports/imports.go
+++ b/cmd/gohandlers/commands/helpers/internal/imports/imports.go
@@ -4,8 +4,8 @@ import (
 	"go/ast"
 	"go/token"
 
-	"github.com/ufukty/gohandlers/cmd/gohandlers/internal/pretty/sort"
-	"github.com/ufukty/gohandlers/pkg/inspects"
+	"go.ufukty.com/gohandlers/cmd/gohandlers/internal/pretty/sort"
+	"go.ufukty.com/gohandlers/pkg/inspects"
 )
 
 // bq.Parse and bs.Parse needs for content type check
@@ -54,7 +54,7 @@ func List(infoss map[inspects.Receiver]map[string]inspects.Info) []ast.Spec {
 	imports := []ast.Spec{
 		&ast.ImportSpec{Path: &ast.BasicLit{Kind: token.STRING, Value: `"fmt"`}},
 		&ast.ImportSpec{Path: &ast.BasicLit{Kind: token.STRING, Value: `"net/http"`}},
-		&ast.ImportSpec{Path: &ast.BasicLit{Kind: token.STRING, Value: `"github.com/ufukty/gohandlers/pkg/gohandlers"`}},
+		&ast.ImportSpec{Path: &ast.BasicLit{Kind: token.STRING, Value: `"go.ufukty.com/gohandlers/pkg/gohandlers"`}},
 	}
 	if needsBytes(infoss) {
 		imports = append(imports,

--- a/cmd/gohandlers/commands/helpers/internal/utilities/asts.go
+++ b/cmd/gohandlers/commands/helpers/internal/utilities/asts.go
@@ -5,7 +5,7 @@ import (
 	"go/ast"
 	"go/token"
 
-	"github.com/ufukty/gohandlers/pkg/inspects"
+	"go.ufukty.com/gohandlers/pkg/inspects"
 )
 
 func quotes(s string) string {

--- a/cmd/gohandlers/commands/helpers/main.go
+++ b/cmd/gohandlers/commands/helpers/main.go
@@ -10,11 +10,11 @@ import (
 	"os"
 	"slices"
 
-	"github.com/ufukty/gohandlers/cmd/gohandlers/commands/helpers/internal/construct"
-	"github.com/ufukty/gohandlers/cmd/gohandlers/commands/helpers/internal/imports"
-	"github.com/ufukty/gohandlers/cmd/gohandlers/commands/helpers/internal/utilities"
-	"github.com/ufukty/gohandlers/cmd/gohandlers/internal/pretty"
-	"github.com/ufukty/gohandlers/pkg/inspects"
+	"go.ufukty.com/gohandlers/cmd/gohandlers/commands/helpers/internal/construct"
+	"go.ufukty.com/gohandlers/cmd/gohandlers/commands/helpers/internal/imports"
+	"go.ufukty.com/gohandlers/cmd/gohandlers/commands/helpers/internal/utilities"
+	"go.ufukty.com/gohandlers/cmd/gohandlers/internal/pretty"
+	"go.ufukty.com/gohandlers/pkg/inspects"
 )
 
 type Args struct {

--- a/cmd/gohandlers/commands/yaml/file.go
+++ b/cmd/gohandlers/commands/yaml/file.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ufukty/gohandlers/pkg/inspects"
+	"go.ufukty.com/gohandlers/pkg/inspects"
 
 	"gopkg.in/yaml.v3"
 )

--- a/cmd/gohandlers/commands/yaml/main.go
+++ b/cmd/gohandlers/commands/yaml/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/ufukty/gohandlers/pkg/inspects"
+	"go.ufukty.com/gohandlers/pkg/inspects"
 )
 
 type Args struct {

--- a/cmd/gohandlers/internal/pretty/print.go
+++ b/cmd/gohandlers/internal/pretty/print.go
@@ -10,8 +10,8 @@ import (
 	"io"
 	"strings"
 
-	"github.com/ufukty/gohandlers/cmd/gohandlers/commands/version"
-	"github.com/ufukty/gohandlers/cmd/gohandlers/internal/pretty/post"
+	"go.ufukty.com/gohandlers/cmd/gohandlers/commands/version"
+	"go.ufukty.com/gohandlers/cmd/gohandlers/internal/pretty/post"
 )
 
 func Print(f *ast.File) (io.Reader, error) {

--- a/cmd/gohandlers/main.go
+++ b/cmd/gohandlers/main.go
@@ -7,10 +7,10 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/ufukty/gohandlers/cmd/gohandlers/commands/client"
-	"github.com/ufukty/gohandlers/cmd/gohandlers/commands/helpers"
-	"github.com/ufukty/gohandlers/cmd/gohandlers/commands/version"
-	"github.com/ufukty/gohandlers/cmd/gohandlers/commands/yaml"
+	"go.ufukty.com/gohandlers/cmd/gohandlers/commands/client"
+	"go.ufukty.com/gohandlers/cmd/gohandlers/commands/helpers"
+	"go.ufukty.com/gohandlers/cmd/gohandlers/commands/version"
+	"go.ufukty.com/gohandlers/cmd/gohandlers/commands/yaml"
 )
 
 func listcmds(commands map[string]func() error) string {

--- a/docs/1. Basics/1.installation.md
+++ b/docs/1. Basics/1.installation.md
@@ -4,7 +4,7 @@ Generating code requires `gohandlers` command to be installed. To stamp the gene
 
 ```sh
 cd "$(mktemp -d)"
-git clone https://github.com/ufukty/gohandlers
+git clone https://go.ufukty.com/gohandlers
 cd gohandlers
 make install
 ```
@@ -12,7 +12,7 @@ make install
 If you don't mind the generated files miss the version number you can use go command as well:
 
 ```sh
-go install github.com/ufukty/gohandlers@latest
+go install go.ufukty.com/gohandlers@latest
 ```
 
 Either way you need to make sure you installed the binary onto a PATH accessible location. If so this command should print at least one line of binary locations:
@@ -24,7 +24,7 @@ which -a gohandlers
 You also need the get the gohandlers package provided by the same repository. Switch to the directory of your project's module root and get the package. Don't forget to run vendor your dependencies if you enabled it previously:
 
 ```sh
-go get github.com/ufukty/gohandlers/pkg/gohandlers
+go get go.ufukty.com/gohandlers/pkg/gohandlers
 # go mod vendor
 ```
 

--- a/docs/2. Usage/1.listing-handlers.md
+++ b/docs/2. Usage/1.listing-handlers.md
@@ -5,7 +5,7 @@ For a directory contains a combination of function and method handlers you'll ge
 ```go
 package handlers
 
-import "github.com/ufukty/gohandlers/pkg/gohandlers"
+import "go.ufukty.com/gohandlers/pkg/gohandlers"
 
 func ListHandlers() map[string]gohandlers.HandlerInfo
 func (u *User) ListHandlers() map[string]gohandlers.HandlerInfo
@@ -65,7 +65,7 @@ package receptionist
 import (
   "net/http"
 
-  "github.com/ufukty/gohandlers/pkg/gohandlers"
+  "go.ufukty.com/gohandlers/pkg/gohandlers"
 )
 
 func Register(l *slog.Logger, m *http.ServeMux, h map[string]gohandlers.HandlerInfo)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ufukty/gohandlers
+module go.ufukty.com/gohandlers
 
 go 1.23.0
 

--- a/pkg/inspects/dir.go
+++ b/pkg/inspects/dir.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/ufukty/gohandlers/pkg/inspects/join"
+	"go.ufukty.com/gohandlers/pkg/inspects/join"
 )
 
 func first[E any](i iter.Seq[E]) (e E) {

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -7,7 +7,7 @@ package validator
 import (
 	"regexp"
 
-	"github.com/ufukty/gohandlers/pkg/validator/validate"
+	"go.ufukty.com/gohandlers/pkg/validator/validate"
 )
 
 type Strings struct {


### PR DESCRIPTION
Updates the module name to use the custom go module proxy server instead of the mirror-specific URL

`github.com/ufukty/gohandlers` -> `go.ufukty.com/gohandlers`