### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/ufukty/gohandlers/security/code-scanning/1](https://github.com/ufukty/gohandlers/security/code-scanning/1)

To fix the problem, explicitly declare minimal `GITHUB_TOKEN` permissions in the workflow. Since this job only checks out code and runs tests and does not need to write to the repository, issues, or pull requests, the least-privilege configuration is `contents: read`. You can set this either at the workflow root (applies to all jobs) or at the job level. Here, adding a job-level `permissions` block under `build-and-test` is sufficient and keeps the change tightly scoped.

Concretely, in `.github/workflows/go-tests.yml`, under `jobs: build-and-test:` and at the same indentation level as `runs-on:`, add:

```yaml
permissions:
  contents: read
```

This constrains the `GITHUB_TOKEN` for this job to read-only repository contents, without affecting any other behavior. No additional imports, libraries, or methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
